### PR TITLE
Avoid creating the engine in the UI thread

### DIFF
--- a/src/main/kotlin/com/teamdev/jxbrowser/quickstart/gradle/compose/App.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/quickstart/gradle/compose/App.kt
@@ -34,24 +34,26 @@ import com.teamdev.jxbrowser.view.compose.BrowserView
  * This example demonstrates how to embed a BrowserView component
  * into a Compose Desktop application and load a web page.
  */
-fun main() = singleWindowApplication(
-    title = "Compose Desktop BrowserView",
-    state = WindowState(width = 700.dp, height = 500.dp),
-) {
+fun main() {
     // Initialize Chromium.
-    val engine = remember { Engine(OFF_SCREEN) }
+    val engine = Engine(OFF_SCREEN)
 
     // Create a Browser instance.
-    val browser = remember { engine.newBrowser() }
+    val browser = engine.newBrowser()
 
-    // Add a BrowserView composable to display web content.
-    BrowserView(browser)
+    singleWindowApplication(
+        title = "Compose Desktop BrowserView",
+        state = WindowState(width = 700.dp, height = 500.dp),
+    ) {
+        // Add a BrowserView composable to display web content.
+        BrowserView(browser)
 
-    DisposableEffect(Unit) {
-        browser.navigation.loadUrl("https://html5test.teamdev.com")
-        onDispose {
-            // Shutdown Chromium and release allocated resources.
-            engine.close()
+        DisposableEffect(Unit) {
+            browser.navigation.loadUrl("https://html5test.teamdev.com")
+            onDispose {
+                // Shutdown Chromium and release allocated resources.
+                engine.close()
+            }
         }
     }
 }

--- a/src/main/kotlin/com/teamdev/jxbrowser/quickstart/gradle/compose/App.kt
+++ b/src/main/kotlin/com/teamdev/jxbrowser/quickstart/gradle/compose/App.kt
@@ -21,7 +21,6 @@
 package com.teamdev.jxbrowser.quickstart.gradle.compose
 
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.singleWindowApplication


### PR DESCRIPTION
JxBrowser entities should be created outside of `singleWindowApplication`.